### PR TITLE
Remove example of a github dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,10 @@ UUID generator and utilities for [Elixir](http://elixir-lang.org/). See [RFC 412
 
 Add as a dependency in your `mix.exs` file:
 
-Releases published through [Hex.pm](https://hex.pm/):
+Releases published through [hex.pm](https://hex.pm/packages/uuid):
 ```elixir
 defp deps do
   [ { :uuid, "~> 0.1.1" } ]
-end
-```
-
-Or directly from GitHub:
-```elixir
-defp deps do
-  [ { :uuid, github: "zyro/elixir-uuid" } ]
 end
 ```
 


### PR DESCRIPTION
Nice library.

I have made this change because it's not really recommended to use a git dependency, especially when there is a package available on hex.pm. Mixing git and hex dependencies can screw your builds.
