### PR TITLE
Replace internal utility functions

### DIFF
--- a/lib/uuid.ex
+++ b/lib/uuid.ex
@@ -487,20 +487,7 @@ defmodule UUID do
     []
   end
   defp list_to_hex_str([head | tail]) do
-    to_hex_str(head) ++ list_to_hex_str(tail)
-  end
-
-  # Hex character integer to hex string.
-  defp to_hex_str(n) when n < 256 do
-    [to_hex(div(n, 16)), to_hex(rem(n, 16))]
-  end
-
-  # Integer to hex character.
-  defp to_hex(i) when i < 10 do
-    0 + i + 48
-  end
-  defp to_hex(i) when i >= 10 and i < 16 do
-    ?a + (i - 10)
+    Integer.to_char_list(head) ++ list_to_hex_str(tail)
   end
 
   # Hex character to integer.


### PR DESCRIPTION
Replace `list_to_hex_str` internal function per `Integer.to_char_list`, which is an Elixir built-in function.