### PR TITLE
Replace internal utility functions

### DIFF
--- a/lib/uuid.ex
+++ b/lib/uuid.ex
@@ -487,20 +487,7 @@ defmodule UUID do
     []
   end
   defp list_to_hex_str([head | tail]) do
-    to_hex_str(head) ++ list_to_hex_str(tail)
-  end
-
-  # Hex character integer to hex string.
-  defp to_hex_str(n) when n < 256 do
-    [to_hex(div(n, 16)), to_hex(rem(n, 16))]
-  end
-
-  # Integer to hex character.
-  defp to_hex(i) when i < 10 do
-    0 + i + 48
-  end
-  defp to_hex(i) when i >= 10 and i < 16 do
-    ?a + (i - 10)
+    Integer.to_char_list(head, 16) ++ list_to_hex_str(tail)
   end
 
   # Hex character to integer.


### PR DESCRIPTION
Replace `to_hex_str/1`(and `to_hex`) internal function per `Integer.to_char_list/1`, which is an Elixir built-in function. 

This change also improves the overall performance:

Now:

```
## UUIDBench
binary_to_string!     1000000   2.12 µs/op
uuid3 dns             1000000   2.42 µs/op
uuid5 dns             1000000   2.70 µs/op
uuid4                  500000   3.24 µs/op
string_to_binary!      500000   5.31 µs/op
info!                  500000   5.96 µs/op
uuid1                   10000   146.32 µs/op
```

Before:
```
## UUIDBench
binary_to_string!      500000   3.16 µs/op
uuid3 dns              500000   3.71 µs/op
uuid5 dns              500000   4.00 µs/op
uuid4                  500000   4.43 µs/op
string_to_binary!      500000   5.49 µs/op
info!                  500000   6.01 µs/op
uuid1                   10000   149.06 µs/op
```

Another readability improvement can be the following:

```diff
diff --git a/lib/uuid.ex b/lib/uuid.ex
index 097d8bc..cf2b32b 100644
--- a/lib/uuid.ex
+++ b/lib/uuid.ex
@@ -470,8 +470,7 @@ defmodule UUID do

   # Binary data to list of hex characters.
   defp binary_to_hex_list(binary) do
-    :binary.bin_to_list(binary)
-      |> list_to_hex_str
+    Base.encode16(binary)
   end

   # Hex string to hex character list.
@@ -482,14 +481,6 @@ defmodule UUID do
     [to_int(x) * 16 + to_int(y) | hex_str_to_list(tail)]
   end

-  # List of hex characters to a hex character string.
-  defp list_to_hex_str([]) do
-    []
-  end
-  defp list_to_hex_str([head | tail]) do
-    Integer.to_char_list(head) ++ list_to_hex_str(tail)
-  end
-
   # Hex character to integer.
   defp to_int(c) when ?0 <= c and c <= ?9 do
     c - ?0
``` 

But this change will impact directly in the performance, for that reason I'll wait for your feedback.

NOTE: This is a continuation of #6 