### PR TITLE
Add type specs to functions.

### DIFF
--- a/lib/uuid.ex
+++ b/lib/uuid.ex
@@ -16,6 +16,15 @@ defmodule UUID do
 
   @urn "urn:uuid:" # UUID URN prefix.
 
+  @type format :: :default | :hex | :urn
+  @type variant ::
+    :reserved_future |
+    :reserved_microsoft |
+    :reserved_ncs |
+    :rfc4122
+  @type namespace_or_uuid :: :dns | :nil | :oid | :url | :x500 | binary
+
+
   @doc """
   Inspect a UUID and return information about its 128-bit binary content, type,
   version and variant.
@@ -56,8 +65,9 @@ defmodule UUID do
    variant: :rfc4122]
 
   ```
-
   """
+  @spec info!(binary) :: [binary: <<_::128>>] | [type: format] |
+    [uuid: String.t] | [variant: variant] | [version: byte]
   def info!(<<uuid::binary>> = uuid_string) do
     {type, <<uuid::128>>} = uuid_string_to_hex_pair(uuid)
     <<_::48, version::4, _::12, v0::1, v1::1, v2::1, _::61>> = <<uuid::128>>
@@ -95,6 +105,7 @@ defmodule UUID do
   ```
 
   """
+  @spec binary_to_string!(binary, format) :: String.t
   def binary_to_string!(uuid, format \\ :default)
   def binary_to_string!(<<uuid::binary>>, format) do
     uuid_to_string(<<uuid::binary>>, format)
@@ -127,6 +138,7 @@ defmodule UUID do
   ```
 
   """
+  @spec string_to_binary!(String.t) :: <<_::128>>
   def string_to_binary!(<<uuid::binary>>) do
     {_type, <<uuid::128>>} = uuid_string_to_hex_pair(uuid)
     <<uuid::128>>
@@ -157,6 +169,7 @@ defmodule UUID do
   ```
 
   """
+  @spec uuid1(format) :: String.t
   def uuid1(format \\ :default) do
     uuid1(uuid1_clockseq(), uuid1_node(), format)
   end
@@ -184,6 +197,7 @@ defmodule UUID do
   ```
 
   """
+  @spec uuid1(<<_::14>>, <<_::48>>, format) :: String.t
   def uuid1(clock_seq, node, format \\ :default)
   def uuid1(<<clock_seq::14>>, <<node::48>>, format) do
     <<time_hi::12, time_mid::16, time_low::32>> = uuid1_time()
@@ -226,6 +240,8 @@ defmodule UUID do
   ```
 
   """
+
+  @spec uuid3(namespace_or_uuid, binary, format) :: String.t
   def uuid3(namespace_or_uuid, name, format \\ :default)
   def uuid3(:dns, <<name::binary>>, format) do
     namebased_uuid(:md5, <<"6ba7b8109dad11d180b400c04fd430c8", name::binary>>)
@@ -295,12 +311,14 @@ defmodule UUID do
   ```
 
   """
+  @spec uuid4 :: String.t
   def uuid4(), do: uuid4(:strong, :default)
 
   def uuid4(:strong), do: uuid4(:strong, :default)
   def uuid4(:weak),   do: uuid4(:weak, :default)
   def uuid4(format),  do: uuid4(:strong, format)
 
+  @spec uuid4(:strong | :weak, format) :: String.t
   def uuid4(:strong, format) do
     <<u0::48, _::4, u1::12, _::2, u2::62>> = :crypto.strong_rand_bytes(16)
     <<u0::48, @uuid_v4::4, u1::12, @variant10::2, u2::62>>
@@ -344,6 +362,7 @@ defmodule UUID do
   ```
 
   """
+  @spec uuid5(namespace_or_uuid, binary, format) :: String.t
   def uuid5(namespace_or_uuid, name, format \\ :default)
   def uuid5(:dns, <<name::binary>>, format) do
     namebased_uuid(:sha1, <<"6ba7b8109dad11d180b400c04fd430c8", name::binary>>)
@@ -380,6 +399,7 @@ defmodule UUID do
   #
 
   # Convert UUID bytes to String.
+  @spec uuid_to_string(<<_::128>>, format) :: String.t
   defp uuid_to_string(<<u0::32, u1::16, u2::16, u3::16, u4::48>>, :default) do
     [binary_to_hex_list(<<u0::32>>), ?-, binary_to_hex_list(<<u1::16>>), ?-,
      binary_to_hex_list(<<u2::16>>), ?-, binary_to_hex_list(<<u3::16>>), ?-,
@@ -403,6 +423,10 @@ defmodule UUID do
   end
 
   # Extract the type (:default etc) and pure byte value from a UUID String.
+  @spec uuid_string_to_hex_pair(binary) ::
+    {:default, <<_::128>>} |
+    {:hex, <<_::128>>} |
+    {:urn, <<_::128>>}
   defp uuid_string_to_hex_pair(<<uuid::binary>>) do
     uuid = String.downcase(uuid)
     {type, hex_str} = case uuid do
@@ -483,6 +507,11 @@ defmodule UUID do
   end
 
   # Identify the UUID variant according to section 4.1.1 of RFC 4122.
+  @spec variant(<<_::24>>) ::
+    :reserved_future |
+    :reserved_microsoft |
+    :reserved_ncs |
+    :rfc4122
   defp variant(<<1, 1, 1>>) do
     :reserved_future
   end

--- a/lib/uuid.ex
+++ b/lib/uuid.ex
@@ -22,7 +22,7 @@ defmodule UUID do
     :reserved_microsoft |
     :reserved_ncs |
     :rfc4122
-  @type namespace_or_uuid :: :dns | :nil | :oid | :url | :x500 | binary
+  @type namespace :: :dns | :nil | :oid | :url | :x500
 
 
   @doc """
@@ -241,7 +241,7 @@ defmodule UUID do
 
   """
 
-  @spec uuid3(namespace_or_uuid, binary, format) :: String.t
+  @spec uuid3(namespace | binary, binary, format) :: String.t
   def uuid3(namespace_or_uuid, name, format \\ :default)
   def uuid3(:dns, <<name::binary>>, format) do
     namebased_uuid(:md5, <<"6ba7b8109dad11d180b400c04fd430c8", name::binary>>)
@@ -362,7 +362,7 @@ defmodule UUID do
   ```
 
   """
-  @spec uuid5(namespace_or_uuid, binary, format) :: String.t
+  @spec uuid5(namespace | binary, binary, format) :: String.t
   def uuid5(namespace_or_uuid, name, format \\ :default)
   def uuid5(:dns, <<name::binary>>, format) do
     namebased_uuid(:sha1, <<"6ba7b8109dad11d180b400c04fd430c8", name::binary>>)

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
-%{"benchfella": {:hex, :benchfella, "0.3.0"},
-  "earmark": {:hex, :earmark, "0.2.1"},
-  "ex_doc": {:hex, :ex_doc, "0.11.4"}}
+%{"benchfella": {:hex, :benchfella, "0.3.0", "bfc150807e6db74200382f44ec85d07782f759130940fdade48c77362884e288", [:mix], []},
+  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.11.4", "a064bdb720594c3745b94709b17ffb834fd858b4e0c1f48f37c0d92700759e02", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]}}


### PR DESCRIPTION
Though this package is well-documented, type specs add an additional layer of clarity, and furthermore, safety (thanks to `dialyzer`/`dialyxir`).

Additionally, https://github.com/zyro/elixir-uuid/pull/18 goes further and drops methods which use un-idiomatic error-handling, which this package should consider incorporating in order to abide by OTP idioms; namely: avoiding the raising of custom errors, and preferring instead to code "the happy path", allowing the program crash on its own whenever it diverges from that path. The catch-all error handling prevents this natural behaviour from happening, contributes to boilerplate, and suppresses the standard (and informative) stack-trace.
