### PR TITLE
Change package name so that it not collides with popular erlang package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,10 +1,10 @@
 defmodule UUID.Mixfile do
   use Mix.Project
 
-  @version "1.1.7"
+  @version "1.2.0"
 
   def project do
-    [app: :uuid,
+    [app: :elixir_uuid,
      name: "UUID",
      version: @version,
      elixir: "~> 1.0",


### PR DESCRIPTION
`uuid` is a package that is used a lot in the erlang ecosystem. And if any package has that as a dependency and also uses this the dependencies will collide and it will not work.

There are two ways forward: the erlang `uuid` package changes it's app name, or this package changes the app name. 

Because the erlang package is around much longer and is more popular I would suggest to change this name. I would suggest publishing a new package under the `elixir_uuid` name, and deprecate the uuid named package asking people to upgrade. This will keep all current apps working, and we can fix packages that depend on uuid by updating the dependency to `elixir_uuid`.