### PR TITLE
Update uuid1_node to account for hw_addrs that are not 6 bytes

### DIFF
--- a/lib/uuid.ex
+++ b/lib/uuid.ex
@@ -481,10 +481,13 @@ defmodule UUID do
       :false ->
         uuid1_node(rest)
       {:hwaddr, hw_addr} ->
-        if length(hw_addr) != 6 or Enum.all?(hw_addr, fn(n) -> n == 0 end) do
-          uuid1_node(rest)
-        else
-          :erlang.list_to_binary(hw_addr)
+        cond do
+          Enum.all?(hw_addr, fn(n) -> n == 0 end) ->
+            uuid1_node(rest)
+          length(hw_addr) == 6 ->
+            :erlang.list_to_binary(hw_addr)
+          true ->
+            uuid1_node(rest)
         end
     end
   end


### PR DESCRIPTION
On my machine, I have an interface with a `hw_addr` that's 8 bytes.  This PR fixes a bug in `uuid1_node/1` where such addresses are used for `<<node::48>>` in `uuid1/2`.