### PR TITLE
fix String.strip/1 deprecation warning in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: elixir
 elixir:
-- 1.0.5
+- 1.3.4
 otp_release:
 - 18.0
 sudo: false

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule UUID.Mixfile do
     [app: :elixir_uuid,
      name: "UUID",
      version: @version,
-     elixir: "~> 1.0",
+     elixir: "~> 1.3",
      docs: [extras: ["README.md", "CHANGELOG.md"],
             main: "readme",
             source_ref: "v#{@version}"],

--- a/test/uuid_test.exs
+++ b/test/uuid_test.exs
@@ -34,7 +34,7 @@ defmodule UUIDTest do
   #   test name || expected output || input value
   for line <- File.stream!(Path.join([__DIR__, "info_tests.txt"]), [], :line) do
     [name, expected, input] =
-      line |> String.split("||") |> Enum.map(&String.strip(&1))
+      line |> String.split("||") |> Enum.map(&String.trim/1)
     test "UUID.info!/1 #{name}" do
       {expected, []} = Code.eval_string(unquote(expected))
       result = UUID.info!(unquote(input))


### PR DESCRIPTION
`String.split` has been [deprecated](https://hexdocs.pm/elixir/deprecations.html) in Elixir 1.5 in favor on `String.trim` which has been introduced in Elixir 1.3.

This also means that the package would require `~ 1.3`