### PR TITLE
Cache MAC address to speed up uuid1/0

### DIFF
--- a/bench/uuid_bench.exs
+++ b/bench/uuid_bench.exs
@@ -4,6 +4,10 @@ defmodule UUIDBench do
   @uuid_string "716c654f-d2b7-436b-9751-2440a9cb079d"
   @uuid_binary <<113, 108, 101, 79, 210, 183, 67, 107, 151, 81, 36, 64, 169, 203, 7, 157>>
 
+  setup_all do
+    Application.ensure_all_started(:elixir_uuid)
+  end
+
   bench "info!" do
     UUID.info!(@uuid_string)
   end
@@ -17,7 +21,7 @@ defmodule UUIDBench do
   end
 
   bench "uuid1" do
-    UUID.uuid1
+    UUID.uuid1()
     :ok
   end
 
@@ -26,12 +30,11 @@ defmodule UUIDBench do
   end
 
   bench "uuid4" do
-    UUID.uuid4
+    UUID.uuid4()
     :ok
   end
 
   bench "uuid5 dns" do
     UUID.uuid5(:dns, "test.example.com")
   end
-
 end

--- a/lib/uuid/application.ex
+++ b/lib/uuid/application.ex
@@ -1,0 +1,9 @@
+defmodule UUID.Application do
+  @moduledoc false
+
+  use Application
+
+  def start(_type, _args) do
+    Supervisor.start_link([UUID.Node], strategy: :one_for_one)
+  end
+end

--- a/lib/uuid/node.ex
+++ b/lib/uuid/node.ex
@@ -1,0 +1,91 @@
+defmodule UUID.Node do
+  @moduledoc false
+
+  use GenServer
+
+  @persistent_term_available Code.ensure_loaded(:persistent_term) == {:module, :persistent_term}
+
+  def start_link([] = _options) do
+    GenServer.start_link(__MODULE__, :no_state)
+  end
+
+  if @persistent_term_available do
+    def get() do
+      :persistent_term.get(:__uuid_mac_address__)
+    rescue
+      _ -> uuid1_node()
+    end
+  else
+    def get() do
+      case :ets.lookup(__MODULE__, :__uuid_mac_address__) do
+        [] -> uuid1_node()
+        [{_key, node}] -> node
+      end
+    end
+  end
+
+  ## Callbacks
+
+  @impl true
+  def init(:no_state) do
+    _ = start_key_value_store()
+    _ = schedule_next_refresh()
+    _ = store_updated(uuid1_node())
+    {:ok, :no_state}
+  end
+
+  @impl true
+  def handle_info(:refresh, state) do
+    _ = store_updated(uuid1_node())
+    {:noreply, state}
+  end
+
+  ## Helpers
+
+  defp schedule_next_refresh() do
+    Process.send_after(self(), :refresh, 10_000)
+  end
+
+  if @persistent_term_available do
+    defp start_key_value_store(), do: IO.inspect(:ok)
+  else
+    defp start_key_value_store() do
+      :ets.new(__MODULE__, [:public, :named_table, read_concurrency: true])
+    end
+  end
+
+  if @persistent_term_available do
+    defp store_updated(value) do
+      :persistent_term.put(:__uuid_mac_address__, value)
+    end
+  else
+    defp store_updated(value) do
+      :ets.insert(__MODULE__, {:__uuid_mac_address__, value})
+    end
+  end
+
+  # Get local IEEE 802 (MAC) address, or a random node id if it can't be found.
+  defp uuid1_node() do
+    {:ok, ifs0} = :inet.getifaddrs()
+    uuid1_node(ifs0)
+  end
+
+  defp uuid1_node([{_if_name, if_config} | rest]) do
+    case :lists.keyfind(:hwaddr, 1, if_config) do
+      false ->
+        uuid1_node(rest)
+
+      {:hwaddr, hw_addr} ->
+        if length(hw_addr) != 6 or Enum.all?(hw_addr, fn n -> n == 0 end) do
+          uuid1_node(rest)
+        else
+          :erlang.list_to_binary(hw_addr)
+        end
+    end
+  end
+
+  defp uuid1_node(_) do
+    <<rnd_hi::7, _::1, rnd_low::40>> = :crypto.strong_rand_bytes(6)
+    <<rnd_hi::7, 1::1, rnd_low::40>>
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,8 @@ defmodule UUID.Mixfile do
 
   # Application configuration.
   def application do
-    []
+    [extra_applications: [:crypto],
+     mod: {UUID.Application, []}]
   end
 
   # List of dependencies.


### PR DESCRIPTION
Closes #40.

Getting the MAC address (through `:inet.getifaddrs/0`) is slow, resulting in the `uuid1/0` function being around 100x slower than the other UUID functions. With this commit we're starting up a GenServer that caches the MAC address in `:persistent_term` if available or ETS otherwise. This GenServer refreshes the MAC address every 10 seconds.

Benchmark **before**:
```
## UUIDBench
benchmark name     iterations   average time 
binary_to_string!     1000000   1.17 µs/op
uuid3 dns             1000000   1.48 µs/op
uuid5 dns             1000000   1.67 µs/op
uuid4                 1000000   2.10 µs/op
string_to_binary!     1000000   2.98 µs/op
info!                  500000   3.18 µs/op
uuid1                   10000   218.52 µs/op
```

Benchmark **after**:
```
## UUIDBench
benchmark name     iterations   average time 
binary_to_string!     1000000   1.15 µs/op
uuid3 dns             1000000   1.48 µs/op
uuid5 dns             1000000   1.56 µs/op
uuid4                 1000000   2.03 µs/op
uuid1                 1000000   2.21 µs/op
info!                 1000000   2.97 µs/op
string_to_binary!     1000000   3.00 µs/op
```

cc @zyro, sorry it took a few months to get to this 😄 