### PR TITLE
Adds :crypto as a dependency in extra_applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,9 @@ defmodule UUID.Mixfile do
 
   # Application configuration.
   def application do
-    []
+    [
+      extra_applications: [:crypto]
+    ]
   end
 
   # List of dependencies.


### PR DESCRIPTION
This is in order to stop Elixir 1.11 warning about undeclared dependencies.

```
==> elixir_uuid
Compiling 1 file (.ex)
warning: :crypto.hash/2 defined in application :crypto is used by the current application but the current application does not directly depend on :crypto. To fix this, you must do one of:

  1. If :crypto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :crypto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :crypto, you may optionally skip this warning by adding [xref: [exclude: :crypto] to your "def project" in mix.exs

Found at 2 locations:
  lib/uuid.ex:589: UUID.namebased_uuid/2
  lib/uuid.ex:593: UUID.namebased_uuid/2
```