### PR TITLE
Use SPDX ID for license in mixfile

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule UUID.Mixfile do
   defp package do
     [files: ["lib", "mix.exs", "README.md", "LICENSE"],
      maintainers: ["Andrei Mihu"],
-     licenses: ["Apache 2.0"],
+     licenses: ["Apache-2.0"],
      links: %{"GitHub" => "https://github.com/zyro/elixir-uuid"}]
   end
 


### PR DESCRIPTION
This is recommended by Hex.pm, and it helps tools identify which license this package is released under.