### PR TITLE
Added :crypto as an extra application

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,9 @@ defmodule UUID.Mixfile do
 
   # Application configuration.
   def application do
-    []
+    [
+      extra_applications: [:crypto]
+    ]
   end
 
   # List of dependencies.


### PR DESCRIPTION
When compiling this dependency, I'm facing the following warning:

```
==> uuid
Compiling 1 file (.ex)
warning: :crypto.hash/2 defined in application :crypto is used by the current application but the current application does not depend on :crypto. To fix this, you must do one of:

  1. If :crypto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :crypto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :crypto, you may optionally skip this warning by adding [xref: [exclude: [:crypto]]] to your "def project" in mix.exs

Invalid call found at 2 locations:
  lib/uuid.ex:498: UUID.namebased_uuid/2
  lib/uuid.ex:502: UUID.namebased_uuid/2

warning: :crypto.strong_rand_bytes/1 defined in application :crypto is used by the current application but the current application does not depend on :crypto. To fix this, you must do one of:

  1. If :crypto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :crypto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :crypto, you may optionally skip this warning by adding [xref: [exclude: [:crypto]]] to your "def project" in mix.exs

Invalid call found at 3 locations:
  lib/uuid.ex:340: UUID.uuid4/1
  lib/uuid.ex:469: UUID.uuid1_clockseq/0
  lib/uuid.ex:492: UUID.uuid1_node/1

Generated uuid app
```

This PR contains and update to purge out this warning.

Compiler logs after adding `:crypto` in extra applications:
```
==> elixir_uuid
Compiling 1 file (.ex)
Generated elixir_uuid app
```