### PR TITLE
Allow setting and retrieving timestamps for UUIDv1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ Changelog
 
 ### Unreleased changes
 
-None.
+* [Enhancement] A new 4-arity function `UUID.uuid1/4` has been added which allows the caller to provide the timestamp for the UUIDv1 as either a 60-bit bitstring (`<<time::60>>`) or a `DateTime`.
+* [Enhancement] A new function `uuid1_gettime/1` has been added which takes a UUIDv1 (either string or binary) and returns the extracted timestamp as a `DateTime` object.
 
 ---
 

--- a/lib/uuid.ex
+++ b/lib/uuid.ex
@@ -252,9 +252,11 @@ defmodule UUID do
   See `uuid/1` for examples.
   """
   def uuid1(time, clock_seq, node, format)
-  def uuid1(time = %DateTime{}, clock_seq, node, format) do
-    uuid1(uuid1_time(time), clock_seq, node, format)
-  end
+  def uuid1(time = %DateTime{}, clock_seq, node, format), do: uuid1(uuid1_time(time), clock_seq, node, format)
+  def uuid1(nil, clock_seq, node, format), do: uuid1(uuid1_time(), clock_seq, node, format)
+  def uuid1(time, nil, node, format), do: uuid1(time, uuid1_clockseq(), node, format)
+  def uuid1(time, clock_seq, nil, format), do: uuid1(time, clock_seq, uuid1_node(), format)
+  def uuid1(time, clock_seq, node, nil), do: uuid1(time, clock_seq, node, :default)
   def uuid1(<<time::60>>, <<clock_seq::14>>, <<node::48>>, format) do
     <<time_hi::12, time_mid::16, time_low::32>> = <<time::60>>
     <<clock_seq_hi::6, clock_seq_low::8>> = <<clock_seq::14>>

--- a/lib/uuid.ex
+++ b/lib/uuid.ex
@@ -299,6 +299,11 @@ defmodule UUID do
     end
   end
 
+  def uuid1_gettime!(uuid) do
+    {:ok, time} = uuid1_gettime(uuid)
+    time
+  end
+
   @doc """
   Generate a new UUID v3. This version uses an MD5 hash of fixed value (chosen
   based on a namespace atom - see Appendix C of

--- a/lib/uuid.ex
+++ b/lib/uuid.ex
@@ -243,32 +243,13 @@ defmodule UUID do
   end
 
   @doc """
-  Generate a new UUID v1, with an existing clock sequence and node address. This
+  Generate a new UUID v1, with an existing time, clock sequence and node address. This
   version uses a combination of one or more of: unix epoch, random bytes,
   pid hash, and hardware address.
 
-  ## Examples
+  The provided `time` may be either a 60-bit bitstring (`<<time::60>>`) or a `DateTime`.
 
-  ```elixir
-  iex> UUID.uuid1()
-  "cdfdaf44-ee35-11e3-846b-14109ff1a304"
-
-  iex> UUID.uuid1(:default)
-  "cdfdaf44-ee35-11e3-846b-14109ff1a304"
-
-  iex> UUID.uuid1(:hex)
-  "cdfdaf44ee3511e3846b14109ff1a304"
-
-  iex> UUID.uuid1(:urn)
-  "urn:uuid:cdfdaf44-ee35-11e3-846b-14109ff1a304"
-
-  iex> UUID.uuid1(:raw)
-  <<205, 253, 175, 68, 238, 53, 17, 227, 132, 107, 20, 16, 159, 241, 163, 4>>
-
-  iex> UUID.uuid1(:slug)
-  "zf2vRO41EeOEaxQQn_GjBA"
-  ```
-
+  See `uuid/1` for examples.
   """
   def uuid1(time, clock_seq, node, format)
   def uuid1(time = %DateTime{}, clock_seq, node, format) do
@@ -286,10 +267,21 @@ defmodule UUID do
     "Invalid argument; Expected: <<clock_seq::14>>, <<node::48>>"
   end
 
+  @doc """
+  Generate a new UUID v1, with an existing clock sequence and node address. This
+  version uses a combination of one or more of: unix epoch, random bytes,
+  pid hash, and hardware address.
+
+  See `uuid/1` for examples.
+  """
   def uuid1(clock_seq, node, format \\ :default) do
     uuid1(uuid1_time(), clock_seq, node, format)
   end
 
+  @doc """
+  Extract and return the timestamp from a UUIDv1 (variant 2) as a `DateTime`. The UUID may be
+  provided in any of the formats accepted by `info/1`.
+  """
   def uuid1_gettime(uuid)
   def uuid1_gettime(<<time_low::32, time_mid::16, @uuid_v1::4, time_hi::12, @variant10::2, _::62>>) do
     goofy_time = :binary.decode_unsigned(<<0::4, time_hi::12, time_mid::16, time_low::32>>, :big)

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,9 @@ defmodule UUID.Mixfile do
 
   # Application configuration.
   def application do
-    []
+    [
+      extra_applications: [:crypto]
+    ]
   end
 
   # List of dependencies.

--- a/test/uuid_test.exs
+++ b/test/uuid_test.exs
@@ -104,4 +104,15 @@ defmodule UUIDTest do
     end
   end
 
+  describe "uuid1_gettime!" do
+    test "invalid arguments" do
+      assert_raise MatchError, fn -> UUID.uuid1_gettime!(0) end
+      assert_raise MatchError, fn -> UUID.uuid1_gettime!(UUID.uuid4()) end
+    end
+
+    test "gets time from a string or binary uuid" do
+      assert %DateTime{} = UUID.uuid1_gettime!(UUID.uuid1())
+      assert %DateTime{} = UUID.uuid1_gettime!(UUID.uuid1(:raw))
+    end
+  end
 end


### PR DESCRIPTION
This PR adds two new functions:

* A 4-arity version of `uuid1` which accepts a `time` parameter as either a 60-bit bitstring or a `DateTime`, allowing the caller to provide the timestamp for use in the generated UUID.
* `uuid1_gettime/1` which accepts a UUIDv1 (in any of the usual formats) and returns the embedded timestamp as a `DateTime`.

This is useful for me specifically because we use Cassandra and the UUIDv1s generated by this library are compatible with its [timeuuid column type](https://docs.datastax.com/en/cql-oss/3.3/cql/cql_reference/uuid_type_r.html). Although Cassandra provides [functions](https://docs.datastax.com/en/cql-oss/3.3/cql/cql_reference/timeuuid_functions_r.html) to extract timestamps from these timeuuids, there is no function to create a timeuuid from a timestamp, so I can't insert elements with a timestamp other than "now".

I added tests for the existing functionality that I touched as well as the newly added functionality.

Thanks for this great library! :)